### PR TITLE
feat: #34 - add save filter functionality

### DIFF
--- a/.changeset/blue-kiwis-reflect.md
+++ b/.changeset/blue-kiwis-reflect.md
@@ -1,0 +1,7 @@
+---
+"sap-knowledge-hub-extension": minor
+"@sap/knowledge-hub-extension-types": minor
+"@sap/knowledge-hub-extension-webapp": minor
+---
+
+feat: #34 - add save filter functionality

--- a/packages/ide-extension/src/extension.ts
+++ b/packages/ide-extension/src/extension.ts
@@ -18,7 +18,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
         commands.registerCommand('sap.ux.knowledgeHub.openKnowledgeHub', async () => {
             try {
                 logString(`Knowledge Hub command called. Options: ${JSON.stringify(context.extensionPath)}`);
-                const knowledgeHubPanel = new KnowledgeHubPanel(context.extensionPath);
+                const knowledgeHubPanel = new KnowledgeHubPanel(context);
                 knowledgeHubPanel.show();
             } catch (error) {
                 window.showErrorMessage(`Error while starting Knowledge Hub: ${(error as Error).message}`);

--- a/packages/ide-extension/src/knowledge-hub/actionsHandler.ts
+++ b/packages/ide-extension/src/knowledge-hub/actionsHandler.ts
@@ -4,17 +4,30 @@ import {
     KNOWLEDGE_HUB_WEB_VIEW_READY,
     TUTORIALS_FETCH_TUTORIALS,
     BLOGS_FETCH_BLOGS,
+    FILTERS_BLOGS_TAGS,
+    FILTERS_TUTORIALS_TAGS,
     TAGS_FETCH_TAGS,
     initialize,
     fetchBlogs,
     fetchHomeBlogs,
     fetchTutorials,
     fetchHomeTutorials,
-    fetchTags
+    fetchTags,
+    initBlogsFilters,
+    initBlogsQuery,
+    initTutorialsFilters
 } from '@sap/knowledge-hub-extension-types';
-import type { AnyAction, BlogsAPI, TutorialsAPI, TagsAPI } from '@sap/knowledge-hub-extension-types';
+import type {
+    AnyAction,
+    BlogsAPI,
+    TutorialsAPI,
+    TagsAPI,
+    BlogFiltersEntry,
+    TutorialsTagWithTitle
+} from '@sap/knowledge-hub-extension-types';
 import { getCommunityBlogsApi, getDeveloperTutorialsApi, getCommunityTagsApi } from '@sap/knowledge-hub-extension-core';
 
+import type { AppSession } from './appSession';
 import type { ActionsHandlerFn } from './types';
 
 interface ActionsHandlersMap {
@@ -25,6 +38,10 @@ interface ActionsHandlersMap {
  * Class that handles all the actions dispatched from the webview.
  */
 export class ActionHandler {
+    // Application data/state
+    private appSession: AppSession;
+
+    // Webview reference
     private panel: WebviewPanel;
 
     private communityBlogsApi: BlogsAPI;
@@ -34,9 +51,11 @@ export class ActionHandler {
     /**
      * Initializes class properties.
      *
+     * @param {AppSession} appSession The application session
      * @param {WebviewPanel} panel The vscode web panel
      */
-    constructor(panel: WebviewPanel) {
+    constructor(appSession: AppSession, panel: WebviewPanel) {
+        this.appSession = appSession;
         this.panel = panel;
 
         this.communityBlogsApi = getCommunityBlogsApi();
@@ -44,13 +63,21 @@ export class ActionHandler {
         this.communityTagsApi = getCommunityTagsApi();
     }
 
+    private getSavedBlogsFilters = async (): Promise<BlogFiltersEntry[]> => {
+        return this.appSession.storage.getBlogsFilters();
+    };
+
+    private getSavedTutorialsFilters = async (): Promise<TutorialsTagWithTitle[]> => {
+        return this.appSession.storage.getTutorialsFilters();
+    };
+
     /**
      *
      * @param {AnyAction} action An action object
      */
     private fetchHomeTutorials = async (action: AnyAction): Promise<void> => {
         this.panel.webview.postMessage(fetchHomeTutorials.pending(true));
-        const response = await this.developerTutorialsApi.getTutorials(action.options);
+        const response = await this.developerTutorialsApi.getTutorials(action.query);
 
         if (response.status === 'fetched' && response.data) {
             this.panel.webview.postMessage(fetchHomeTutorials.fulfilled(response.data));
@@ -69,7 +96,11 @@ export class ActionHandler {
      */
     private fetchTutorials = async (action: AnyAction): Promise<void> => {
         this.panel.webview.postMessage(fetchTutorials.pending(true));
-        const response = await this.developerTutorialsApi.getTutorials(action.options);
+        const response = await this.developerTutorialsApi.getTutorials(action.query);
+
+        // Save filters
+        const filters = action.filters;
+        this.appSession.storage.setFilters(FILTERS_TUTORIALS_TAGS, filters);
 
         if (response.status === 'fetched' && response.data) {
             this.panel.webview.postMessage(fetchTutorials.fulfilled(response.data));
@@ -88,7 +119,7 @@ export class ActionHandler {
      */
     private fetchHomeBlogs = async (action: AnyAction): Promise<void> => {
         this.panel.webview.postMessage(fetchHomeBlogs.pending(true));
-        const response = await this.communityBlogsApi.getBlogs(action.options);
+        const response = await this.communityBlogsApi.getBlogs(action.query);
 
         if (response.status === 'fetched' && response.data) {
             this.panel.webview.postMessage(fetchHomeBlogs.fulfilled(response.data));
@@ -107,7 +138,11 @@ export class ActionHandler {
      */
     private fetchBlogs = async (action: AnyAction): Promise<void> => {
         this.panel.webview.postMessage(fetchBlogs.pending(true));
-        const response = await this.communityBlogsApi.getBlogs(action.options);
+        const response = await this.communityBlogsApi.getBlogs(action.query);
+
+        // Save filters
+        const filters = action.filters;
+        this.appSession.storage.setFilters(FILTERS_BLOGS_TAGS, filters);
 
         if (response.status === 'fetched' && response.data) {
             this.panel.webview.postMessage(fetchBlogs.fulfilled(response.data));
@@ -140,11 +175,19 @@ export class ActionHandler {
     // Webview actions handlers
     public actionsHandlersMap: ActionsHandlersMap = {
         [KNOWLEDGE_HUB_WEB_VIEW_READY]: async (): Promise<void> => {
+            const blogsFilters: BlogFiltersEntry[] = await this.getSavedBlogsFilters();
+            const tutorialsFilters: TutorialsTagWithTitle[] = await this.getSavedTutorialsFilters();
+
             this.panel.webview.postMessage(
                 initialize.fulfilled({
-                    appId: 'KnowledgeHub'
+                    appId: 'sap.ux.knowledgeHub'
                 })
             );
+
+            this.panel.webview.postMessage(initBlogsFilters.fulfilled(blogsFilters));
+            this.panel.webview.postMessage(initBlogsQuery.fulfilled(blogsFilters));
+
+            this.panel.webview.postMessage(initTutorialsFilters.fulfilled(tutorialsFilters));
         },
         [TUTORIALS_FETCH_TUTORIALS]: async (action: AnyAction): Promise<void> => {
             if (action.home) {

--- a/packages/ide-extension/src/knowledge-hub/appSession.ts
+++ b/packages/ide-extension/src/knowledge-hub/appSession.ts
@@ -1,0 +1,28 @@
+import type { WebviewPanel } from 'vscode';
+import type { Storage } from '../utils/storage';
+
+interface AppSessionProperties {
+    storage: Storage;
+    panel: WebviewPanel;
+}
+
+/**
+ * AppSession is a singleton class that holds the state of the app.
+ */
+export class AppSession {
+    // VSCode internal storage
+    public storage: Storage;
+
+    // VSCode Panel
+    public panel: WebviewPanel;
+
+    /**
+     * Initializes class properties.
+     *
+     * @param {AppSessionProperties} properties - AppSession properties
+     */
+    constructor(properties: AppSessionProperties) {
+        this.storage = properties.storage;
+        this.panel = properties.panel;
+    }
+}

--- a/packages/ide-extension/src/knowledge-hub/messageHandler.ts
+++ b/packages/ide-extension/src/knowledge-hub/messageHandler.ts
@@ -1,9 +1,11 @@
 import type { WebviewPanel } from 'vscode';
 import type { AnyAction } from '@sap/knowledge-hub-extension-types';
 
+import type { ActionHandlerResult, ActionsHandlerFn, ResponseActions } from './types';
+import type { AppSession } from './appSession';
+
 import { ActionHandler } from './actionsHandler';
 import { getGenericRejectAction } from '../actions';
-import type { ActionHandlerResult, ActionsHandlerFn, ResponseActions } from './types';
 
 interface ActionHandleResult {
     status: boolean;
@@ -19,10 +21,11 @@ export class MessageHandler {
     /**
      * Initializes class properties.
      *
-     * @param {WebviewPanel} panel The vscode web panel
+     * @param {WebviewPanel} panel - The vscode web panel
+     * @param {AppSession} appSession - The application session
      */
-    constructor(private readonly panel: WebviewPanel) {
-        this.actionHandler = new ActionHandler(this.panel);
+    constructor(private readonly panel: WebviewPanel, private readonly appSession: AppSession) {
+        this.actionHandler = new ActionHandler(this.appSession, this.panel);
     }
 
     /**

--- a/packages/ide-extension/src/utils/storage.ts
+++ b/packages/ide-extension/src/utils/storage.ts
@@ -1,0 +1,86 @@
+import type { Memento } from 'vscode';
+import type {
+    StorageSettings,
+    AppFilters,
+    BlogFiltersEntry,
+    TutorialsTagWithTitle
+} from '@sap/knowledge-hub-extension-types';
+
+/**
+ * Storage class is a wrapper for VSCode storage.
+ */
+export class Storage implements StorageSettings {
+    private readonly storage: Memento;
+
+    // Storage key
+    private readonly key: string;
+
+    // Settings object from storage
+    private readonly data: StorageSettings;
+
+    /**
+     * Initializes class properties.
+     *
+     * @param {Memento} storage - VSCode storage
+     * @param {string} subPath - Storage key
+     */
+    constructor(storage: Memento, subPath: string) {
+        this.storage = storage;
+        this.key = subPath;
+        this.data = this.storage.get(this.key) || {};
+    }
+
+    /**
+     * Private method which updates storage wwith latest values.
+     */
+    private updateSettings(): void {
+        this.storage.update(this.key, this.data);
+    }
+
+    /**
+     * Getter for property 'appFilters'.
+     *
+     * @returns {AppFilters} Value of 'AppFilters' property.
+     */
+    public get appFilters(): AppFilters {
+        const filters: AppFilters | undefined = this.data.appFilters;
+        return {
+            blogs: filters?.blogs !== undefined ? filters.blogs : [],
+            tutorials: filters?.tutorials !== undefined ? filters.tutorials : []
+        };
+    }
+
+    /**
+     * Setter for property 'AppFilters'.
+     *
+     * @param {string} name Sidebar name.
+     * @param {BlogFiltersEntry[] | TutorialsTagWithTitle []} entry AppFilters value.
+     */
+    public setFilters(name: string & keyof AppFilters, entry: BlogFiltersEntry[] | TutorialsTagWithTitle[]): void {
+        this.data.appFilters = {
+            ...this.appFilters,
+            [name]: entry
+        };
+        this.updateSettings();
+    }
+
+    /**
+     * Getter for property 'blogs AppFilters'.
+     *
+     * @returns {BlogFiltersEntry[]} Value of AppFilters 'blogs' property.
+     */
+    public getBlogsFilters(): BlogFiltersEntry[] {
+        const filters: AppFilters | undefined = this.data.appFilters;
+        return filters?.blogs !== undefined ? filters.blogs : [];
+    }
+
+    /**
+     * Getter for property 'tutorials AppFilters'.
+     *
+     * @returns {TutorialsTagWithTitle[]} Value of AppFilters 'tutorials' property.
+     */
+    public getTutorialsFilters(): TutorialsTagWithTitle[] {
+        const filters: AppFilters | undefined = this.data.appFilters;
+        return filters?.tutorials !== undefined ? filters.tutorials : [];
+    }
+}

--- a/packages/ide-extension/test/unit/knowledge-hub/actionsHandler.test.ts
+++ b/packages/ide-extension/test/unit/knowledge-hub/actionsHandler.test.ts
@@ -1,6 +1,7 @@
 import vscode from 'vscode';
 import type { AnyAction } from '@sap/knowledge-hub-extension-types';
 import { ActionHandler } from '../../../src/knowledge-hub/actionsHandler';
+import { Storage } from '../../../src/utils/storage';
 
 describe('actionsHandler', () => {
     let postMessage: (action: unknown) => Promise<void> = jest.fn();
@@ -42,12 +43,29 @@ describe('actionsHandler', () => {
         dispose: jest.fn()
     };
 
+    const values: { [key: string]: unknown } = {};
+    const extensionContext: vscode.ExtensionContext = {
+        globalState: {
+            get: (key: string): unknown => {
+                return values[key];
+            },
+            update: (key: string, value: unknown): void => {
+                values[key] = value;
+            }
+        } as vscode.Memento
+    } as vscode.ExtensionContext;
+
+    const appSession = {
+        storage: new Storage(extensionContext.globalState, 'app1'),
+        panel: webViewPanel
+    };
+
     const createWebviewPanelSpy = jest.spyOn(vscode.window, 'createWebviewPanel').mockImplementation(() => {
         return webViewPanel;
     });
 
     it('should test `ActionHandler` class', () => {
-        const actionHandler = new ActionHandler(webViewPanel);
+        const actionHandler = new ActionHandler(appSession, webViewPanel);
         expect(actionHandler).toBeDefined();
     });
 });

--- a/packages/ide-extension/test/unit/panels/knowledgeHubPanel.test.ts
+++ b/packages/ide-extension/test/unit/panels/knowledgeHubPanel.test.ts
@@ -1,20 +1,33 @@
+import vscode from 'vscode';
 import { initI18n } from '../../../src/i18n';
 
 import { KnowledgeHubPanel } from '../../../src/panels/knowledgeHubPanel';
 
-beforeAll(() => {
-    initI18n();
-});
-
 describe('knowledgeHubPanel', () => {
+    const values: { [key: string]: unknown } = {};
+    const extensionContext: vscode.ExtensionContext = {
+        globalState: {
+            get: (key: string): unknown => {
+                return values[key];
+            },
+            update: (key: string, value: unknown): void => {
+                values[key] = value;
+            }
+        } as vscode.Memento
+    } as vscode.ExtensionContext;
+
+    beforeAll(() => {
+        initI18n();
+    });
+
     it('should test `KnowledgeHubPanel` class', () => {
-        const knowledgeHubPanel = new KnowledgeHubPanel('extensionPath');
+        const knowledgeHubPanel = new KnowledgeHubPanel(extensionContext);
         expect(knowledgeHubPanel).toBeDefined();
         expect(knowledgeHubPanel.panel).toBeDefined();
     });
 
     it('should test createKnowledgeHubWebview', () => {
-        const knowledgeHubPanel = new KnowledgeHubPanel('extensionPath');
+        const knowledgeHubPanel = new KnowledgeHubPanel(extensionContext);
         const webviewPanel = knowledgeHubPanel.createKnowledgeHubWebview();
         expect(webviewPanel).toBeDefined();
     });

--- a/packages/ide-extension/test/unit/utils/storage.test.ts
+++ b/packages/ide-extension/test/unit/utils/storage.test.ts
@@ -1,0 +1,56 @@
+import { Storage } from '../../../src/utils/storage';
+import type vscode from 'vscode';
+import { FILTERS_BLOGS_TAGS, FILTERS_TUTORIALS_TAGS, BlogFiltersEntryType } from '@sap/knowledge-hub-extension-types';
+
+const values: { [key: string]: unknown } = {};
+const extensionContext: vscode.ExtensionContext = {
+    globalState: {
+        get: (key: string): unknown => {
+            return values[key];
+        },
+        update: (key: string, value: unknown): void => {
+            values[key] = value;
+        }
+    } as vscode.Memento
+} as vscode.ExtensionContext;
+
+describe('utils', () => {
+    describe('Storage', () => {
+        test('Property "appFilters" - value read and write', () => {
+            let storage = new Storage(extensionContext.globalState, 'sap.ux.knowledgeHub.filters');
+            // default
+            expect(storage.appFilters).toEqual({
+                [FILTERS_BLOGS_TAGS]: [],
+                [FILTERS_TUTORIALS_TAGS]: []
+            });
+
+            // Write/change
+            const tutorialsFilter = {
+                tag: 'Tag1',
+                title: 'Tag 1'
+            };
+            const blogsFilter = {
+                id: 'Tag1',
+                label: 'Tag 1',
+                type: BlogFiltersEntryType.TAG
+            };
+            storage.setFilters(FILTERS_TUTORIALS_TAGS, [tutorialsFilter]);
+
+            storage = new Storage(extensionContext.globalState, 'sap.ux.knowledgeHub.filters');
+            expect(storage.appFilters).toEqual({
+                [FILTERS_BLOGS_TAGS]: [],
+                [FILTERS_TUTORIALS_TAGS]: [tutorialsFilter]
+            });
+
+            storage.setFilters(FILTERS_BLOGS_TAGS, [blogsFilter]);
+            storage = new Storage(extensionContext.globalState, 'sap.ux.knowledgeHub.filters');
+            expect(storage.appFilters).toEqual({
+                [FILTERS_BLOGS_TAGS]: [blogsFilter],
+                [FILTERS_TUTORIALS_TAGS]: [tutorialsFilter]
+            });
+
+            expect(storage.getTutorialsFilters()).toEqual([tutorialsFilter]);
+            expect(storage.getBlogsFilters()).toEqual([blogsFilter]);
+        });
+    });
+});

--- a/packages/types/src/const/actions.ts
+++ b/packages/types/src/const/actions.ts
@@ -1,4 +1,11 @@
-import type { App, TutorialsSearchResult, BlogsSearchResult, TagsSearchResult } from '../types';
+import type {
+    App,
+    TutorialsSearchResult,
+    BlogsSearchResult,
+    TagsSearchResult,
+    BlogFiltersEntry,
+    TutorialsTagWithTitle
+} from '../types';
 
 export const VIEW_PREFIX = '[view]';
 export const CORE_PREFIX = '[core]';
@@ -138,3 +145,6 @@ export const fetchBlogs = createCoreAction<BlogsSearchResult>('blogs/fetch');
 export const fetchHomeTutorials = createCoreAction<TutorialsSearchResult>('home/tutorials/fetch');
 export const fetchHomeBlogs = createCoreAction<BlogsSearchResult>('home/blogs/fetch');
 export const fetchTags = createCoreAction<TagsSearchResult>('tags/fetch');
+export const initBlogsQuery = createCoreAction<BlogFiltersEntry[]>('blogs/init/query');
+export const initBlogsFilters = createCoreAction<BlogFiltersEntry[]>('blogs/init/filters');
+export const initTutorialsFilters = createCoreAction<TutorialsTagWithTitle[]>('tutorials/init/filters');

--- a/packages/types/src/types/actions.ts
+++ b/packages/types/src/types/actions.ts
@@ -1,5 +1,5 @@
-import type { TutorialsSearchQuery } from './tutorials.types';
-import type { BlogsSearchQuery } from './blogs.types';
+import type { TutorialsSearchQuery, TutorialsTagWithTitle } from './tutorials.types';
+import type { BlogsSearchQuery, BlogFiltersEntry } from './blogs.types';
 export interface PendingActions {
     [key: string]: boolean;
 }
@@ -33,13 +33,15 @@ export interface KnowledgeHubWebViewReady {
 
 export interface TutorialsFetchTutorials {
     type: typeof TUTORIALS_FETCH_TUTORIALS;
-    options: TutorialsSearchQuery;
+    query: TutorialsSearchQuery;
+    filters: TutorialsTagWithTitle[];
     home: boolean;
 }
 
 export interface BlogsFetchBlogs {
     type: typeof BLOGS_FETCH_BLOGS;
-    options: BlogsSearchQuery;
+    query: BlogsSearchQuery;
+    filters: BlogFiltersEntry[];
     home: boolean;
 }
 

--- a/packages/types/src/types/app.types.ts
+++ b/packages/types/src/types/app.types.ts
@@ -1,3 +1,30 @@
+import type { BlogFiltersEntry } from './blogs.types';
+import type { TutorialsTagWithTitle } from './tutorials.types';
+
+export const SET_GLOBAL_SETTINGS = 'SET_GLOBAL_SETTINGS';
+export const UPDATE_GLOBAL_SETTING = 'UPDATE_GLOBAL_SETTING';
+
+export const FILTERS_BLOGS_TAGS = 'blogs';
+export const FILTERS_TUTORIALS_TAGS = 'tutorials';
+
+export const enum Feature {
+    NATIVE_PROPERTIES = 'NATIVE_PROPERTIES',
+    SHOW_PROPERTIES_DESCRIPTIONS = 'SHOW_PROPERTIES_DESCRIPTIONS',
+    FPM_FEATURES = 'FPM_FEATURES',
+    ZERO_STATE_FEATURE = 'ZERO_STATE_FEATURE',
+    BUILDING_BLOCK_EDITOR = 'BUILDING_BLOCK_EDITOR',
+    NEW_TREE_EDITOR = 'NEW_TREE_EDITOR'
+}
+
 export interface App {
     appId: string;
+}
+
+export interface StorageSettings {
+    appFilters?: AppFilters;
+}
+
+export interface AppFilters {
+    [FILTERS_BLOGS_TAGS]?: BlogFiltersEntry[];
+    [FILTERS_TUTORIALS_TAGS]?: TutorialsTagWithTitle[];
 }

--- a/packages/types/src/types/tutorials.types.ts
+++ b/packages/types/src/types/tutorials.types.ts
@@ -83,6 +83,11 @@ export interface TutorialsFacets {
     [index: string]: string[];
 }
 
+export interface TutorialsTagWithTitle {
+    tag: string;
+    title: string;
+}
+
 // API
 
 export interface TutorialsAPI {

--- a/packages/webapp/src/webview/components/BlogsFiltersBar/BlogsFiltersBar.tsx
+++ b/packages/webapp/src/webview/components/BlogsFiltersBar/BlogsFiltersBar.tsx
@@ -7,8 +7,9 @@ import { UIIcon } from '@sap-ux/ui-components';
 
 import { BlogFiltersEntry, BlogFiltersEntryType, BlogsSearchQuery } from '@sap/knowledge-hub-extension-types';
 
-import { store, actions, useAppSelector } from '../../store';
+import { store, useAppSelector } from '../../store';
 import { getBlogsUIFiltersEntries } from '../../features/blogs/Blogs.slice';
+import { fetchBlogData } from '../../features/blogs/Blogs.utils';
 import {
     blogsManagedTagsDelete,
     blogsManagedTagsDeleteAll,
@@ -16,8 +17,7 @@ import {
     blogsCategoryDelete,
     blogsCategoryDeleteAll,
     blogsFilterEntryDelete,
-    blogsFilterEntryDeleteAll,
-    blogsLoading
+    blogsFilterEntryDeleteAll
 } from '../../store/actions';
 
 import { UIPill } from '../UI/UIPill/UIPill';
@@ -30,11 +30,6 @@ export const BlogsFiltersBar: FC = (): JSX.Element => {
     const dispatch = useDispatch();
     const activeFiltersEntries = useAppSelector(getBlogsUIFiltersEntries);
     const [filtersEntries, setFiltersEntries] = useState<BlogFiltersEntry[]>([]);
-
-    const fetchData = (option: BlogsSearchQuery) => {
-        dispatch(blogsLoading(true));
-        actions.blogsFetchBlogs(option, false);
-    };
 
     const onClearAllFilterEntries = useCallback((): void => {
         const state = store.getState();
@@ -49,7 +44,7 @@ export const BlogsFiltersBar: FC = (): JSX.Element => {
         dispatch(blogsManagedTagsDeleteAll(null));
         dispatch(blogsLanguageUpdate(null));
         dispatch(blogsFilterEntryDeleteAll(null));
-        fetchData(options);
+        fetchBlogData(options);
     }, []);
 
     const onClearFilterEntry = useCallback((id: string): void => {
@@ -79,7 +74,7 @@ export const BlogsFiltersBar: FC = (): JSX.Element => {
             }
         }
         dispatch(blogsFilterEntryDelete(id));
-        fetchData(options);
+        fetchBlogData(options);
     }, []);
 
     useEffect(() => {

--- a/packages/webapp/src/webview/components/TutorialCard/TaskType/TaskType.tsx
+++ b/packages/webapp/src/webview/components/TutorialCard/TaskType/TaskType.tsx
@@ -1,20 +1,18 @@
 import React from 'react';
 import type { FC } from 'react';
 import { UIIcon } from '@sap-ux/ui-components';
-import type { TutorialsTags } from '@sap/knowledge-hub-extension-types';
 
 import './TaskType.scss';
 
 type TaskTypeProps = {
     type: string;
-    tags?: TutorialsTags;
 };
 
-export const TaskType: FC<TaskTypeProps> = ({ type, tags }: TaskTypeProps): JSX.Element => {
+export const TaskType: FC<TaskTypeProps> = ({ type }: TaskTypeProps): JSX.Element => {
     return (
         <div className="task-type">
             <UIIcon iconName="task" />
-            <span className="task-type-text">{tags && tags[type].title}</span>
+            <span className="task-type-text">{type}</span>
         </div>
     );
 };

--- a/packages/webapp/src/webview/components/TutorialCard/TutorialCard.tsx
+++ b/packages/webapp/src/webview/components/TutorialCard/TutorialCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import type { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -18,7 +18,7 @@ type TutorialCardProps = {
     tag?: string;
     tags?: TutorialsTags;
     loading?: boolean;
-    onSelectedTag(tag: string): void;
+    onSelectedTag(tag: string, isChecked: boolean): void;
 };
 
 export const TutorialCard: FC<TutorialCardProps> = ({
@@ -29,6 +29,10 @@ export const TutorialCard: FC<TutorialCardProps> = ({
     onSelectedTag
 }: TutorialCardProps): JSX.Element => {
     const { t } = useTranslation();
+
+    const onClickedTag = useCallback((tag: string) => {
+        onSelectedTag(tag, true);
+    }, []);
 
     const getFullNameForTag = (tag: string): string => {
         if (tags && tags[tag]) {
@@ -55,7 +59,7 @@ export const TutorialCard: FC<TutorialCardProps> = ({
                         </div>
                         <div className="tutorial-card-header-info">
                             <div className="tutorial-card-header-info-task-type">
-                                <TaskType type={tutorial.taskType} tags={tags} />
+                                <TaskType type={getFullNameForTag(tutorial.taskType)} />
                             </div>
                             <div className="tutorial-card-header-info-experience">
                                 <Experience experience={getFullNameForTag(tutorial.experience)} />
@@ -72,7 +76,7 @@ export const TutorialCard: FC<TutorialCardProps> = ({
                             tagText={tag}
                             tagId={tutorial.primaryTag}
                             isFeatured={tutorial.featured}
-                            callback={onSelectedTag}
+                            callback={onClickedTag}
                         />
                         {tutorial.featured && <Featured />}
                     </div>

--- a/packages/webapp/src/webview/components/TutorialsFiltersMenu/TutorialsFiltersMenu.tsx
+++ b/packages/webapp/src/webview/components/TutorialsFiltersMenu/TutorialsFiltersMenu.tsx
@@ -18,16 +18,10 @@ import './TutorialsFiltersMenu.scss';
 export type TutorialsFiltersMenuProps = {
     facets: TutorialsFacets;
     tags: TutorialsTags;
-    onSelectedTag(tag: string): void;
-    onClearedTag(tag: string): void;
+    loading: boolean;
 };
 
-export const TutorialsFiltersMenu: FC<TutorialsFiltersMenuProps> = ({
-    facets,
-    tags,
-    onSelectedTag,
-    onClearedTag
-}): JSX.Element => {
+export const TutorialsFiltersMenu: FC<TutorialsFiltersMenuProps> = ({ facets, tags, loading }): JSX.Element => {
     const activeUi: TutorialsUiState = useAppSelector(getTutorialsUI);
 
     return (
@@ -55,8 +49,7 @@ export const TutorialsFiltersMenu: FC<TutorialsFiltersMenuProps> = ({
                                 tags={tags}
                                 withSearchOn={withSearchOn}
                                 isSmall={isSmall}
-                                onSelectedTag={onSelectedTag}
-                                onClearedTag={onClearedTag}
+                                loading={loading}
                             />
                         );
                     })}

--- a/packages/webapp/src/webview/components/TutorialsFiltersMenu/TutorialsFiltersMenuEntries/TutorialsFiltersMenuEntries.tsx
+++ b/packages/webapp/src/webview/components/TutorialsFiltersMenu/TutorialsFiltersMenuEntries/TutorialsFiltersMenuEntries.tsx
@@ -6,7 +6,7 @@ import { UICheckbox, UISearchBox } from '@sap-ux/ui-components';
 import { TutorialsTags, TUTORIALS_FILTERS_LABELS } from '@sap/knowledge-hub-extension-types';
 
 import { store } from '../../../store';
-import { isFilteredTag } from '../../../features/tutorials/Tutorials.utils';
+import { onTagSelected } from '../../../features/tutorials/Tutorials.utils';
 import { getAlternativeTitles, getTutorialsTag, makeTutorialsTagCompare } from './TutorialsFiltersMenuEntries.utils';
 import type { SortedTagListEntry } from './TutorialsFiltersMenuEntries.utils';
 
@@ -20,8 +20,7 @@ export type TutorialsFiltersMenuEntriesProps = {
     tags: TutorialsTags;
     withSearchOn: boolean;
     isSmall: boolean;
-    onSelectedTag(tag: string): void;
-    onClearedTag(tag: string): void;
+    loading: boolean;
 };
 
 export const TutorialsFiltersMenuEntries: FC<TutorialsFiltersMenuEntriesProps> = ({
@@ -30,31 +29,16 @@ export const TutorialsFiltersMenuEntries: FC<TutorialsFiltersMenuEntriesProps> =
     tags,
     withSearchOn,
     isSmall,
-    onSelectedTag,
-    onClearedTag
+    loading
 }): JSX.Element => {
     const [listEntries, setListEntries] = useState(entries);
-    const [loading, setLoading] = useState(false);
+    const [isLoading, setIsLoading] = useState(loading);
 
     const isTagChecked = useCallback((tagId: string): boolean => {
         const state = store.getState();
         const tagFilters = Object.assign([], state.tutorials.query.filters);
         return tagFilters.includes(tagId);
     }, []);
-
-    const onTagSelected = (tagId: string, checked: boolean): void => {
-        const state = store.getState();
-        const tagFilters = Object.assign([], state.tutorials.query.filters);
-        if (checked) {
-            if (!isFilteredTag(tagId, tagFilters)) {
-                setLoading(true);
-                onSelectedTag(tagId);
-            }
-        } else if (isFilteredTag(tagId, tagFilters)) {
-            setLoading(true);
-            onClearedTag(tagId);
-        }
-    };
 
     const onChange = useCallback(
         (_event: React.ChangeEvent<HTMLInputElement> | undefined, searchItem: string | undefined) => {
@@ -122,9 +106,13 @@ export const TutorialsFiltersMenuEntries: FC<TutorialsFiltersMenuEntriesProps> =
     };
 
     useEffect(() => {
-        setLoading(false);
+        setIsLoading(false);
         setListEntries(entries);
     }, [entries]);
+
+    useEffect(() => {
+        setIsLoading(loading);
+    }, [loading]);
 
     return (
         <div
@@ -134,7 +122,7 @@ export const TutorialsFiltersMenuEntries: FC<TutorialsFiltersMenuEntriesProps> =
             ]
                 .filter((x) => !!x)
                 .join(' ')}>
-            {loading && <Loader blockDOM={true} delayed={true} />}
+            {isLoading && <Loader blockDOM={true} delayed={true} />}
 
             <div className="tutorials-filters-menu-entries__header">
                 <span className="tutorials-filters-menu-entries__header-title">{title}</span>

--- a/packages/webapp/src/webview/features/blogs/Blogs.tsx
+++ b/packages/webapp/src/webview/features/blogs/Blogs.tsx
@@ -21,7 +21,7 @@ import {
 import { store, useAppSelector } from '../../store';
 import { getBlogs, getBlogsQuery, getManagedTags, getBlogsUIIsLoading } from './Blogs.slice';
 import { getTagsData } from '../tags/Tags.slice';
-import { fetchData, isManagedTag, getBlogsTagById, onTagSelected } from './Blogs.utils';
+import { fetchBlogData, isManagedTag, getBlogsTagById, onTagSelected } from './Blogs.utils';
 import { getSearchTerm } from '../search/Search.slice';
 
 import type { UIPaginationSelected } from '../../components/UI/UIPagination';
@@ -65,7 +65,7 @@ export const Blogs: FC = (): JSX.Element => {
             dispatch(blogsPageChanged(event.selected));
             setPageOffset(event.selected);
 
-            fetchData(options);
+            fetchBlogData(options);
         },
         [activeQuery]
     );
@@ -92,7 +92,7 @@ export const Blogs: FC = (): JSX.Element => {
                 dispatch(blogsManagedTagsAdd(tag.guid));
                 dispatch(blogsTagsAdd({ displayName: tag.displayName, guid: tag.guid }));
                 options.managedTags = [tag.guid];
-                fetchData(options);
+                fetchBlogData(options);
                 navigate(location.pathname, { replace: true });
             } else if (activeBlogs && activeBlogs.totalCount > 0) {
                 setBlogs(activeBlogs.data);
@@ -109,7 +109,7 @@ export const Blogs: FC = (): JSX.Element => {
             } else if (activeBlogs.totalCount === -1) {
                 setLoading(true);
                 setNoResult(false);
-                fetchData(options);
+                fetchBlogData(options);
             }
         }
     }, [activeBlogs]);
@@ -119,7 +119,7 @@ export const Blogs: FC = (): JSX.Element => {
         const currentQuery = state.blogs.query;
         const options: BlogsSearchQuery = Object.assign({}, currentQuery, { searchTerm: activeSearchTerm });
         dispatch(blogsSearchTermChanged(activeSearchTerm));
-        fetchData(options);
+        fetchBlogData(options);
     }, [activeSearchTerm]);
 
     useEffect(() => {

--- a/packages/webapp/src/webview/features/blogs/Blogs.utils.ts
+++ b/packages/webapp/src/webview/features/blogs/Blogs.utils.ts
@@ -5,6 +5,7 @@ import type {
     LanguageId,
     BlogsCategory
 } from '@sap/knowledge-hub-extension-types';
+
 import { BlogFiltersEntryType, allLanguages, blogsCategories } from '@sap/knowledge-hub-extension-types';
 import { store, actions } from '../../store';
 import {
@@ -60,21 +61,26 @@ export const getCategoryLabel = (categoryId: string): string => {
     const category = blogsCategories.find((category: BlogsCategory) => category.id === categoryId);
     return category ? category.label : '';
 };
+
 /**
  * Fetch blogs data.
  *
- * @param {BlogsSearchQuery} option - blogs search query
+ * @param {BlogsSearchQuery} query - The fetch query object
+ * @param {boolean} home Set true if data is for home page or not
  */
-export const fetchData = (option: BlogsSearchQuery) => {
+export const fetchBlogData = (query: BlogsSearchQuery, home?: boolean): void => {
+    const state = store.getState();
+    const filters = state.blogs.ui.filtersEntries;
+
     store.dispatch(blogsLoading(true));
-    actions.blogsFetchBlogs(option, false);
+    actions.blogsFetchBlogs(query, filters, home ? home : false);
 };
 
 /**
  * Function to handle tag selection.
  *
- * @param {Tag} tag The selected tag
- * @param {boolean} checked true|false if tag is selected
+ * @param {Tag} tag - The selected tag
+ * @param {boolean} checked - true|false if tag is selected
  */
 export const onTagSelected = (tag: Tag, checked: boolean): void => {
     const state = store.getState();
@@ -104,14 +110,14 @@ export const onTagSelected = (tag: Tag, checked: boolean): void => {
         store.dispatch(blogsManagedTagsDelete(tag.guid));
     }
     store.dispatch(blogsTagsAdd(tag));
-    const options: BlogsSearchQuery = Object.assign({}, currentQuery, { managedTags: blogTags });
-    fetchData(options);
+    const query: BlogsSearchQuery = Object.assign({}, currentQuery, { managedTags: blogTags });
+    fetchBlogData(query);
 };
 
 /**
  * Function to handle language selection.
  *
- * @param {string} language The selected language
+ * @param {string} language - The selected language
  */
 export const onLanguageSelected = (language: string): void => {
     const state = store.getState();
@@ -126,7 +132,7 @@ export const onLanguageSelected = (language: string): void => {
     store.dispatch(blogsLanguageUpdate(language));
 
     const options: BlogsSearchQuery = Object.assign({}, currentQuery, { language: language });
-    fetchData(options);
+    fetchBlogData(options);
 };
 
 /**
@@ -164,5 +170,5 @@ export const onCategorySelected = (categoryId: string, checked: boolean): void =
     }
 
     const options: BlogsSearchQuery = Object.assign({}, currentQuery, { blogCategories: blogCategories });
-    fetchData(options);
+    fetchBlogData(options);
 };

--- a/packages/webapp/src/webview/features/home/home.utils.ts
+++ b/packages/webapp/src/webview/features/home/home.utils.ts
@@ -1,6 +1,8 @@
 import type { Home, Tags } from '@sap/knowledge-hub-extension-types';
 import { store, actions } from '../../store';
 
+import { fetchBlogData } from '../blogs/Blogs.utils';
+import { fetchTutorialsData } from '../tutorials/Tutorials.utils';
 import { initialHomeBlogsUIState, initialHomeTutorialsUIState } from './Home.slice';
 
 /**
@@ -10,7 +12,7 @@ export const fecthHomeBlogs = (): void => {
     const state = store.getState();
     const homeState: Home = state.home;
     if (homeState.blogs.blogs.totalCount === 0) {
-        actions.blogsFetchBlogs(initialHomeBlogsUIState, true);
+        fetchBlogData(initialHomeBlogsUIState, true);
     }
 };
 
@@ -21,7 +23,7 @@ export const fecthHomeTutorials = (): void => {
     const state = store.getState();
     const homeState: Home = state.home;
     if (homeState.tutorials.tutorials.data.numFound === 0) {
-        actions.tutorialsFetchTutorials(initialHomeTutorialsUIState, true);
+        fetchTutorialsData(initialHomeTutorialsUIState, true);
     }
 };
 

--- a/packages/webapp/src/webview/features/tutorials/Tutorials.slice.ts
+++ b/packages/webapp/src/webview/features/tutorials/Tutorials.slice.ts
@@ -1,6 +1,11 @@
 import { createSlice, combineReducers } from '@reduxjs/toolkit';
 import type { PayloadAction } from '@reduxjs/toolkit';
-import { fetchTutorials, fetchHomeTutorials, TUTORIALS_LIMIT_PER_PAGE } from '@sap/knowledge-hub-extension-types';
+import {
+    fetchTutorials,
+    fetchHomeTutorials,
+    initTutorialsFilters,
+    TUTORIALS_LIMIT_PER_PAGE
+} from '@sap/knowledge-hub-extension-types';
 import type {
     Tutorials,
     TutorialsTags,
@@ -9,6 +14,7 @@ import type {
     TutorialsSearchQuery,
     TutorialsUiState,
     TutorialsTagsState,
+    TutorialsTagWithTitle,
     Error,
     ErrorAction,
     PendingAction
@@ -20,8 +26,10 @@ import {
     tutorialsFiltersTagsDeleteAll,
     tutorialsFiltersTagsResetWith,
     tutorialsFiltersSelected,
+    tutorialsSearchFieldChanged,
     tutorialsLoading
 } from '../../store/actions';
+
 import type { RootState } from '../../store';
 
 export const initialSearchState: TutorialsState = {
@@ -108,6 +116,17 @@ const query = createSlice({
     reducers: {},
     extraReducers: (builder) =>
         builder
+            .addCase(
+                initTutorialsFilters.fulfilled.type,
+                (state: TutorialsSearchQuery, action: PayloadAction<TutorialsTagWithTitle[]>) => {
+                    const filters: string[] = [];
+                    action.payload.forEach((tagWithTitle: TutorialsTagWithTitle) => {
+                        filters.push(tagWithTitle.tag);
+                    });
+
+                    return { ...state, filters };
+                }
+            )
             .addMatcher(
                 tutorialsPageChanged.match,
                 (state: TutorialsSearchQuery, action: PayloadAction<number>): void => {
@@ -152,6 +171,12 @@ const query = createSlice({
             .addMatcher(tutorialsFiltersTagsDeleteAll.match, (state: TutorialsSearchQuery): void => {
                 state.filters = [];
             })
+            .addMatcher(
+                tutorialsSearchFieldChanged.match,
+                (state: TutorialsSearchQuery, action: PayloadAction<string>): void => {
+                    state.searchField = action.payload;
+                }
+            )
 });
 
 const ui = createSlice({

--- a/packages/webapp/src/webview/features/tutorials/Tutorials.utils.ts
+++ b/packages/webapp/src/webview/features/tutorials/Tutorials.utils.ts
@@ -1,4 +1,11 @@
-import type { TutorialsSearchResult } from '@sap/knowledge-hub-extension-types';
+import type {
+    TutorialsSearchResult,
+    TutorialsSearchQuery,
+    TutorialsTagWithTitle,
+    TutorialsTags
+} from '@sap/knowledge-hub-extension-types';
+import { store, actions } from '../../store';
+import { tutorialsFiltersTagsAdd, tutorialsFiltersTagsDelete, tutorialsLoading } from '../../store/actions';
 
 export const getTutorialsTag = (val: string, allTutorials: TutorialsSearchResult | undefined): string => {
     if (allTutorials && allTutorials.tags && allTutorials.tags[val]) {
@@ -8,6 +15,78 @@ export const getTutorialsTag = (val: string, allTutorials: TutorialsSearchResult
     }
 };
 
+export const getTutorialsTagTitle = (val: string, tags: TutorialsTags): string => {
+    if (tags[val]) {
+        return tags[val].title;
+    } else {
+        return '';
+    }
+};
+
 export const isFilteredTag = (tagId: string, tags: string[]): boolean => {
     return tags.includes(tagId);
+};
+
+export const getTutorialsTagsTitle = (tags: string[], allTags: TutorialsTags): TutorialsTagWithTitle[] => {
+    const tagsWithTitle: TutorialsTagWithTitle[] = [];
+    tags.forEach((tagId: string) => {
+        const title = getTutorialsTagTitle(tagId, allTags);
+
+        tagsWithTitle.push({
+            tag: tagId,
+            title: title
+        });
+    });
+    return tagsWithTitle;
+};
+
+/**
+ * Fetch tutorials data.
+ *
+ * @param {TutorialsSearchQuery} query - The fetch query object
+ * @param {boolean} home - Set true if data is for home page or not
+ */
+export const fetchTutorialsData = (query: TutorialsSearchQuery, home?: boolean): void => {
+    const state = store.getState();
+    const filters: string[] | undefined = state.tutorials.query.filters;
+    let filtersWithTitle: TutorialsTagWithTitle[] = [];
+    const tags = state.tutorials.tags.tags;
+
+    if (filters && filters.length > 0) {
+        filtersWithTitle = getTutorialsTagsTitle(filters, tags);
+    }
+
+    store.dispatch(tutorialsLoading(true));
+    actions.tutorialsFetchTutorials(query, filtersWithTitle, home ? home : false);
+};
+
+/**
+ * Function to handle tag selection.
+ *
+ * @param {string} tagId -  The selected tag
+ * @param {boolean} checked - true|false if tag is selected
+ */
+export const onTagSelected = (tagId: string, checked: boolean): void => {
+    const state = store.getState();
+    const currentQuery = state.tutorials.query;
+    const currentTutorialsFilters = Object.assign([], currentQuery.filters);
+    let tutorialsTags: string[] = [];
+
+    if (checked) {
+        if (currentTutorialsFilters.length > 0) {
+            if (!currentTutorialsFilters.find((element: string) => element === tagId)) {
+                tutorialsTags = currentTutorialsFilters;
+                tutorialsTags.push(tagId);
+            }
+        } else {
+            tutorialsTags = [tagId];
+        }
+        store.dispatch(tutorialsFiltersTagsAdd(tagId));
+    } else {
+        tutorialsTags = currentTutorialsFilters.filter((element: string) => element !== tagId);
+        store.dispatch(tutorialsFiltersTagsDelete(tagId));
+    }
+
+    const query: TutorialsSearchQuery = Object.assign({}, currentQuery, { filters: tutorialsTags });
+    fetchTutorialsData(query);
 };

--- a/packages/webapp/src/webview/store/actions.ts
+++ b/packages/webapp/src/webview/store/actions.ts
@@ -6,7 +6,8 @@ import type {
     BlogsSearchQuery,
     BlogFiltersEntry,
     Tag,
-    TagsFetchTags
+    TagsFetchTags,
+    TutorialsTagWithTitle
 } from '@sap/knowledge-hub-extension-types';
 
 import {
@@ -21,15 +22,25 @@ export const knowledgeHubWebViewReady = (): KnowledgeHubWebViewReady => ({
     type: KNOWLEDGE_HUB_WEB_VIEW_READY
 });
 
-export const tutorialsFetchTutorials = (options: TutorialsSearchQuery, home: boolean): TutorialsFetchTutorials => ({
+export const tutorialsFetchTutorials = (
+    query: TutorialsSearchQuery,
+    filters: TutorialsTagWithTitle[],
+    home: boolean
+): TutorialsFetchTutorials => ({
     type: TUTORIALS_FETCH_TUTORIALS,
-    options,
+    query,
+    filters,
     home
 });
 
-export const blogsFetchBlogs = (options: BlogsSearchQuery, home: boolean): BlogsFetchBlogs => ({
+export const blogsFetchBlogs = (
+    query: BlogsSearchQuery,
+    filters: BlogFiltersEntry[],
+    home: boolean
+): BlogsFetchBlogs => ({
     type: BLOGS_FETCH_BLOGS,
-    options,
+    query,
+    filters,
     home
 });
 
@@ -64,4 +75,5 @@ export const tutorialsFiltersTagsDelete = createViewAction<string>('tutorials/fi
 export const tutorialsFiltersTagsDeleteAll = createViewAction('tutorials/filters-tags-delete-all');
 export const tutorialsFiltersTagsResetWith = createViewAction<string>('tutorials/filters-tags-reset-with');
 export const tutorialsFiltersSelected = createViewAction<boolean>('tutorials/filters-selected');
+export const tutorialsSearchFieldChanged = createViewAction<string>('tutorials/change-searchField');
 export const tutorialsLoading = createViewAction<boolean>('tutorials/loading');

--- a/packages/webapp/test/components/BlogsFiltersMenu/BlogsFiltersMenuLanguages/BlogsFiltersMenuLanguages.test.tsx
+++ b/packages/webapp/test/components/BlogsFiltersMenu/BlogsFiltersMenuLanguages/BlogsFiltersMenuLanguages.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { act, fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import type { RenderResult } from '@testing-library/react';
 
 import { initIcons } from '@sap-ux/ui-components';

--- a/packages/webapp/test/components/TutorialCard/TaskType.test.tsx
+++ b/packages/webapp/test/components/TutorialCard/TaskType.test.tsx
@@ -3,8 +3,6 @@ import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
 import type { RenderResult } from '@testing-library/react';
 
-import type { TutorialsTags } from '@sap/knowledge-hub-extension-types';
-
 import { initIcons } from '@sap-ux/ui-components';
 import { initLCIcons } from '../../../src/webview/Icons/icons';
 
@@ -18,24 +16,15 @@ describe('TutorialCard > TaskType', () => {
     initIcons();
     initLCIcons();
 
-    const renderTaskType = (type: string, tags: TutorialsTags): RenderResult =>
-        render(<TaskType type={type} tags={tags} />, { initialState: { tutorials: withDataNoError } });
+    const renderTaskType = (type: string): RenderResult =>
+        render(<TaskType type={type} />, { initialState: { tutorials: withDataNoError } });
 
     test('test if the TaskType render is ok', () => {
-        const type =
-            'c1a376dd-ebd0-4787-804e-a23fef23ba06:b79e26e3-025a-455b-a9e5-3047ed76bad2/3245916d-3b2b-4818-8611-5beaff01a2f8';
-        const tags = {
-            'c1a376dd-ebd0-4787-804e-a23fef23ba06:b79e26e3-025a-455b-a9e5-3047ed76bad2/3245916d-3b2b-4818-8611-5beaff01a2f8':
-                {
-                    tagAlternativeTitles: [],
-                    title: 'Group',
-                    tagTitle: 'tutorial:type/group'
-                }
-        };
+        const type = 'task-type-text';
 
-        renderTaskType(type, tags);
+        renderTaskType(type);
 
-        const typeDOM = screen.getByText(/Group/i);
+        const typeDOM = screen.getByText(/task-type-text/i);
         expect(typeDOM.className).toEqual('task-type-text');
     });
 });

--- a/packages/webapp/test/components/TutorialsFiltersBar/TutorialsFiltersBar.test.tsx
+++ b/packages/webapp/test/components/TutorialsFiltersBar/TutorialsFiltersBar.test.tsx
@@ -17,22 +17,13 @@ describe('TutorialsFiltersBar', () => {
     initIcons();
     initLCIcons();
 
-    const renderTutorialsFiltersBar = (
-        onClearAllTagFilter: {
-            (): void;
-            (): void;
-        },
-        onClearTagFilter: { (tagId: string): void; (tagId: string): void }
-    ): RenderResult =>
-        render(<TutorialsFiltersBar clearAllTags={onClearAllTagFilter} clearTag={onClearTagFilter} />, {
+    const renderTutorialsFiltersBar = (): RenderResult =>
+        render(<TutorialsFiltersBar />, {
             initialState: { tutorials: withDataNoErrorWithFilters }
         });
 
     test('test if the TutorialsFiltersBar render is ok with data', () => {
-        const onClearAllTagFilterfn = jest.fn();
-        const onClearTagFilterfn = jest.fn();
-
-        renderTutorialsFiltersBar(onClearAllTagFilterfn, onClearTagFilterfn);
+        renderTutorialsFiltersBar();
 
         const filteredHeaderDOM = screen.getByText(/TUTORIALS_FILTERS_BAR_FILTERED_BY/i);
         expect(filteredHeaderDOM.className).toEqual('tutorials-filters-bar-header-title');
@@ -45,10 +36,7 @@ describe('TutorialsFiltersBar', () => {
     });
 
     test('test if the TutorialsFiltersBar render is ok when the clear all filters is clicked', () => {
-        const onClearAllTagFilterfn = jest.fn();
-        const onClearTagFilterfn = jest.fn();
-
-        renderTutorialsFiltersBar(onClearAllTagFilterfn, onClearTagFilterfn);
+        renderTutorialsFiltersBar();
 
         const listOfFilterPill = screen.getByTestId('tutorials-filters-bar-list-of-pill').querySelectorAll('.ui-pill');
         expect(listOfFilterPill.length).toEqual(3);
@@ -60,35 +48,12 @@ describe('TutorialsFiltersBar', () => {
             act(() => {
                 clearAllDOM.dispatchEvent(new MouseEvent('click', { bubbles: true }));
             });
-            expect(onClearAllTagFilterfn).toHaveBeenCalled();
-        }
-    });
-
-    test('test if the TutorialsFiltersBar render is ok when the clear all filters is clicked', () => {
-        const onClearAllTagFilterfn = jest.fn();
-        const onClearTagFilterfn = jest.fn();
-
-        renderTutorialsFiltersBar(onClearAllTagFilterfn, onClearTagFilterfn);
-
-        const listOfFilterPill = screen.getByTestId('tutorials-filters-bar-list-of-pill').querySelectorAll('.ui-pill');
-        expect(listOfFilterPill.length).toEqual(3);
-
-        const clearAllDOM = screen.getByText(/TUTORIALS_FILTERS_BAR_CLEAR_ALL/i);
-        expect(clearAllDOM.className).toContain('ms-Button-label');
-
-        if (clearAllDOM) {
-            act(() => {
-                clearAllDOM.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-            });
-            expect(onClearAllTagFilterfn).toHaveBeenCalled();
+            expect(() => screen.getByTestId('tutorials-filters-bar')).toThrow();
         }
     });
 
     test('test if the TutorialsFiltersBar render is ok when one of the filter clear icon is clicked', () => {
-        const onClearAllTagFilterfn = jest.fn();
-        const onClearTagFilterfn = jest.fn();
-
-        renderTutorialsFiltersBar(onClearAllTagFilterfn, onClearTagFilterfn);
+        renderTutorialsFiltersBar();
 
         let listOfFilterPill = screen
             .getByTestId('tutorials-filters-bar-list-of-pill')
@@ -99,7 +64,6 @@ describe('TutorialsFiltersBar', () => {
             act(() => {
                 listOfFilterPill[0].dispatchEvent(new MouseEvent('click', { bubbles: true }));
             });
-            expect(onClearTagFilterfn).toHaveBeenCalled();
         }
     });
 });

--- a/packages/webapp/test/components/TutorialsFiltersMenu/TutorialsFiltersMenu.test.tsx
+++ b/packages/webapp/test/components/TutorialsFiltersMenu/TutorialsFiltersMenu.test.tsx
@@ -19,23 +19,10 @@ describe('TutorialsFiltersMenu', () => {
     initIcons();
     initLCIcons();
 
-    const renderTutorialsFiltersMenu = (
-        facets: TutorialsFacets,
-        tags: TutorialsTags,
-        onTagSelected: { (tagId: string): void; (tagId: string): void },
-        onClearedTag: { (tagId: string): void; (tagId: string): void }
-    ): RenderResult =>
-        render(
-            <TutorialsFiltersMenu
-                facets={facets}
-                tags={tags}
-                onSelectedTag={onTagSelected}
-                onClearedTag={onClearedTag}
-            />,
-            {
-                initialState: { tutorials: withDataNoErrorWithFilters }
-            }
-        );
+    const renderTutorialsFiltersMenu = (facets: TutorialsFacets, tags: TutorialsTags, loading: boolean): RenderResult =>
+        render(<TutorialsFiltersMenu facets={facets} tags={tags} loading={loading} />, {
+            initialState: { tutorials: withDataNoErrorWithFilters }
+        });
 
     test('test if the TutorialsFiltersMenu render is ok with data', () => {
         const facets = {
@@ -116,10 +103,8 @@ describe('TutorialsFiltersMenu', () => {
                 tagAlternativeTitles: []
             }
         };
-        const onTagSelected = jest.fn();
-        const onClearedTag = jest.fn();
 
-        renderTutorialsFiltersMenu(facets, tags, onTagSelected, onClearedTag);
+        renderTutorialsFiltersMenu(facets, tags, false);
 
         const filteredMenuTitleDOM = screen.getByText('Topic');
         expect(filteredMenuTitleDOM.className).toEqual('tutorials-filters-menu-entries__header-title');

--- a/packages/webapp/test/components/TutorialsFiltersMenu/TutorialsFiltersMenuEntries/TutorialsFiltersMenuEntries.test.tsx
+++ b/packages/webapp/test/components/TutorialsFiltersMenu/TutorialsFiltersMenuEntries/TutorialsFiltersMenuEntries.test.tsx
@@ -99,7 +99,8 @@ describe('TutorialsFiltersMenuEntries', () => {
         entries: string[],
         tags: TutorialsTags,
         withSearchOn: boolean,
-        isSmall: boolean
+        isSmall: boolean,
+        loading: boolean
     ): RenderResult =>
         render(
             <TutorialsFiltersMenuEntries
@@ -108,6 +109,7 @@ describe('TutorialsFiltersMenuEntries', () => {
                 tags={tags}
                 withSearchOn={withSearchOn}
                 isSmall={isSmall}
+                loading={loading}
             />,
             {
                 initialState: { tutorials: withDataNoErrorWithFilters }
@@ -119,8 +121,9 @@ describe('TutorialsFiltersMenuEntries', () => {
         const entries = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4'];
         const withSearchOn = true;
         const isSmall = false;
+        const loading = false;
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, loading);
 
         const filteredMenuTitleDOM = screen.getByText(/Topic/i);
         expect(filteredMenuTitleDOM.className).toEqual('tutorials-filters-menu-entries__header-title');
@@ -135,8 +138,9 @@ describe('TutorialsFiltersMenuEntries', () => {
 
         const withSearchOn = false;
         const isSmall = false;
+        const loading = false;
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, loading);
 
         const filteredMenuTitleDOM = screen.getByText(/Topic/i);
         expect(filteredMenuTitleDOM.className).toEqual('tutorials-filters-menu-entries__header-title');
@@ -150,8 +154,9 @@ describe('TutorialsFiltersMenuEntries', () => {
         const entries = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4'];
         const withSearchOn = true;
         const isSmall = false;
+        const loading = false;
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, loading);
 
         const searchInput = screen.getByRole('searchbox');
         expect(searchInput).toBeInTheDocument();
@@ -185,9 +190,10 @@ describe('TutorialsFiltersMenuEntries', () => {
         const entries = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4'];
         const withSearchOn = true;
         const isSmall = false;
+        const loading = false;
         const spyOnTagSelected = jest.spyOn(utils, 'onTagSelected');
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, loading);
 
         const filteredMenuTitleDOM = screen.getByText(/Topic/i);
         expect(filteredMenuTitleDOM.className).toEqual('tutorials-filters-menu-entries__header-title');
@@ -217,8 +223,9 @@ describe('TutorialsFiltersMenuEntries', () => {
         const entries = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4', 'Tag 5'];
         const withSearchOn = true;
         const isSmall = false;
+        const loading = false;
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, loading);
 
         const searchInput = screen.getByRole('searchbox');
         if (searchInput) {

--- a/packages/webapp/test/components/TutorialsFiltersMenu/TutorialsFiltersMenuEntries/TutorialsFiltersMenuEntries.test.tsx
+++ b/packages/webapp/test/components/TutorialsFiltersMenu/TutorialsFiltersMenuEntries/TutorialsFiltersMenuEntries.test.tsx
@@ -8,12 +8,13 @@ import userEvent from '@testing-library/user-event';
 import { initIcons } from '@sap-ux/ui-components';
 import { initLCIcons } from '../../../../src/webview/Icons/icons';
 
-import type { TutorialsTags, TutorialsFacets } from '@sap/knowledge-hub-extension-types';
+import type { TutorialsTags } from '@sap/knowledge-hub-extension-types';
 
-import { withDataNoErrorWithFilters, withDataNoErrorWithFiltersSelected } from '../../../__mocks__/tutorials';
+import { withDataNoErrorWithFilters } from '../../../__mocks__/tutorials';
 import { render } from '../../../__mocks__/store.mock';
 
 import { TutorialsFiltersMenuEntries } from '../../../../src/webview/components/TutorialsFiltersMenu/TutorialsFiltersMenuEntries';
+import * as utils from '../../../../src/webview/features/tutorials/Tutorials.utils';
 
 describe('TutorialsFiltersMenuEntries', () => {
     // Initialize and register ui-components icons and specific icon to LC
@@ -98,9 +99,7 @@ describe('TutorialsFiltersMenuEntries', () => {
         entries: string[],
         tags: TutorialsTags,
         withSearchOn: boolean,
-        isSmall: boolean,
-        onSelectedTag: { (tag: string): void; (tag: string): void },
-        onClearedTag: { (tag: string): void; (tag: string): void }
+        isSmall: boolean
     ): RenderResult =>
         render(
             <TutorialsFiltersMenuEntries
@@ -109,8 +108,6 @@ describe('TutorialsFiltersMenuEntries', () => {
                 tags={tags}
                 withSearchOn={withSearchOn}
                 isSmall={isSmall}
-                onSelectedTag={onSelectedTag}
-                onClearedTag={onClearedTag}
             />,
             {
                 initialState: { tutorials: withDataNoErrorWithFilters }
@@ -122,10 +119,8 @@ describe('TutorialsFiltersMenuEntries', () => {
         const entries = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4'];
         const withSearchOn = true;
         const isSmall = false;
-        const onSelectedTag = jest.fn();
-        const onClearedTag = jest.fn();
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, onSelectedTag, onClearedTag);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
 
         const filteredMenuTitleDOM = screen.getByText(/Topic/i);
         expect(filteredMenuTitleDOM.className).toEqual('tutorials-filters-menu-entries__header-title');
@@ -140,10 +135,8 @@ describe('TutorialsFiltersMenuEntries', () => {
 
         const withSearchOn = false;
         const isSmall = false;
-        const onSelectedTag = jest.fn();
-        const onClearedTag = jest.fn();
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, onSelectedTag, onClearedTag);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
 
         const filteredMenuTitleDOM = screen.getByText(/Topic/i);
         expect(filteredMenuTitleDOM.className).toEqual('tutorials-filters-menu-entries__header-title');
@@ -157,10 +150,8 @@ describe('TutorialsFiltersMenuEntries', () => {
         const entries = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4'];
         const withSearchOn = true;
         const isSmall = false;
-        const onSelectedTag = jest.fn();
-        const onClearedTag = jest.fn();
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, onSelectedTag, onClearedTag);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
 
         const searchInput = screen.getByRole('searchbox');
         expect(searchInput).toBeInTheDocument();
@@ -194,10 +185,9 @@ describe('TutorialsFiltersMenuEntries', () => {
         const entries = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4'];
         const withSearchOn = true;
         const isSmall = false;
-        const onSelectedTag = jest.fn();
-        const onClearedTag = jest.fn();
+        const spyOnTagSelected = jest.spyOn(utils, 'onTagSelected');
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, onSelectedTag, onClearedTag);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
 
         const filteredMenuTitleDOM = screen.getByText(/Topic/i);
         expect(filteredMenuTitleDOM.className).toEqual('tutorials-filters-menu-entries__header-title');
@@ -216,7 +206,7 @@ describe('TutorialsFiltersMenuEntries', () => {
                 // Simulate click
                 fireEvent.click(screen.getAllByRole('checkbox')?.[0]);
 
-                expect(onSelectedTag).toHaveBeenCalledWith('Tag 1');
+                expect(spyOnTagSelected).toHaveBeenCalledWith('Tag 1', true);
             }
         }
     });
@@ -227,10 +217,8 @@ describe('TutorialsFiltersMenuEntries', () => {
         const entries = ['Tag 1', 'Tag 2', 'Tag 3', 'Tag 4', 'Tag 5'];
         const withSearchOn = true;
         const isSmall = false;
-        const onSelectedTag = jest.fn();
-        const onClearedTag = jest.fn();
 
-        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall, onSelectedTag, onClearedTag);
+        renderTutorialsFiltersMenuEntries(title, entries, tags, withSearchOn, isSmall);
 
         const searchInput = screen.getByRole('searchbox');
         if (searchInput) {

--- a/packages/webapp/test/features/blogs/Blogs.slice.test.tsx
+++ b/packages/webapp/test/features/blogs/Blogs.slice.test.tsx
@@ -1,7 +1,7 @@
-import { fetchBlogs, BlogFiltersEntryType } from '@sap/knowledge-hub-extension-types';
+import { fetchBlogs, BlogFiltersEntryType, initBlogsFilters, initBlogsQuery } from '@sap/knowledge-hub-extension-types';
 import type { Blogs } from '@sap/knowledge-hub-extension-types';
-import reducer from '../../../src/webview/features/blogs/Blogs.slice';
-import {
+
+import reducer, {
     getBlogs,
     getBlogsError,
     getBlogsQuery,
@@ -29,7 +29,8 @@ import {
     blogsLoading,
     blogsFilterEntryAdd,
     blogsFilterEntryDelete,
-    blogsFilterEntryDeleteAll
+    blogsFilterEntryDeleteAll,
+    blogsSearchTermChanged
 } from '../../../src/webview/store/actions';
 
 import {
@@ -74,6 +75,23 @@ describe('blogs slice', () => {
         });
 
         describe('blogs slice > reducer > blogsQuery', () => {
+            test('blogs init filters', () => {
+                const state = Object.assign({}, initialState, {
+                    query: {
+                        ...initialState.query,
+                        blogCategories: ['testCategory'],
+                        managedTags: ['testTag'],
+                        language: 'en'
+                    }
+                });
+                const action = initBlogsQuery.fulfilled([
+                    { id: 'testTag', label: 'Test tag', type: BlogFiltersEntryType.TAG },
+                    { id: 'testCategory', label: 'Test category', type: BlogFiltersEntryType.CATEGORY },
+                    { id: 'en', label: 'English', type: BlogFiltersEntryType.LANGUAGE }
+                ]);
+                expect(reducer(initialState, action)).toEqual(state);
+            });
+
             test('blogs page changed action', () => {
                 const state = Object.assign({}, initialState, {
                     query: {
@@ -203,7 +221,18 @@ describe('blogs slice', () => {
                 expect(reducer(uiInitialState, blogsCategoryDeleteAll(''))).toEqual(state);
             });
 
-            test('blogs update search term action - blogsSearchTermChanged', () => {});
+            test('blogs update search term action - blogsSearchTermChanged', () => {
+                const uiInitialState = Object.assign({}, initialState, {
+                    query: { ...initialState.query, searchTerm: '' }
+                });
+                const state = Object.assign({}, initialState, {
+                    query: {
+                        ...initialState.query,
+                        searchTerm: 'test'
+                    }
+                });
+                expect(reducer(uiInitialState, blogsSearchTermChanged('test'))).toEqual(state);
+            });
         });
 
         describe('blogs slice > reducer > blogsTags', () => {
@@ -252,6 +281,25 @@ describe('blogs slice', () => {
         });
 
         describe('blogs slice > reducer > blogsUI', () => {
+            test('blogs init filters', () => {
+                const state = Object.assign({}, initialState, {
+                    ui: {
+                        ...initialState.ui,
+                        filtersEntries: [
+                            {
+                                id: 'testTag',
+                                label: 'Test tag',
+                                type: 'TAG'
+                            }
+                        ]
+                    }
+                });
+                const action = initBlogsFilters.fulfilled([
+                    { id: 'testTag', label: 'Test tag', type: BlogFiltersEntryType.TAG }
+                ]);
+                expect(reducer(initialState, action)).toEqual(state);
+            });
+
             test('blogs is filter menu opened - blogsFiltersSelected', () => {
                 const state = Object.assign({}, initialState, {
                     ui: { isLoading: false, isFiltersMenuOpened: true, filtersEntries: [] }

--- a/packages/webapp/test/features/tutorials/Tutorials.slice.test.tsx
+++ b/packages/webapp/test/features/tutorials/Tutorials.slice.test.tsx
@@ -1,6 +1,6 @@
-import { fetchTutorials, fetchHomeTutorials } from '@sap/knowledge-hub-extension-types';
+import { fetchTutorials, fetchHomeTutorials. initTutorialsFilters } from '@sap/knowledge-hub-extension-types';
 import type { Tutorials } from '@sap/knowledge-hub-extension-types';
-import reducer from '../../../src/webview/features/tutorials/Tutorials.slice';
+
 import {
     tutorialsPageChanged,
     tutorialsFiltersTagsAdd,
@@ -11,7 +11,7 @@ import {
     tutorialsFiltersSelected
 } from '../../../src/webview/store/actions';
 
-import {
+import reducer, {
     getTutorials,
     getTutorialsData,
     getTutorialsPending,
@@ -64,6 +64,19 @@ describe('tutorials slice', () => {
         });
 
         describe('tutorials slice > reducer > tutorialsQuery', () => {
+            test('tutorials init filters', () => {
+                const state = Object.assign({}, initialState, {
+                    query: {
+                        ...initialState.query,
+                        filters: ['testTag']
+                    }
+                });
+                const action = initTutorialsFilters.fulfilled([{ tag: 'testTag', title: 'Test tag' }]);
+                expect(reducer(initialState, action)).toEqual(
+                    state
+                );
+            });
+
             test('tutorials page changed action', () => {
                 const state = Object.assign({}, initialState, {
                     query: {

--- a/packages/webapp/test/store/actions.test.tsx
+++ b/packages/webapp/test/store/actions.test.tsx
@@ -1,5 +1,6 @@
 import * as actions from '../../src/webview/store/actions';
 import * as types from '@sap/knowledge-hub-extension-types';
+import type { BlogFiltersEntry, TutorialsTagWithTitle } from '@sap/knowledge-hub-extension-types';
 
 describe('Page Map redux actions', () => {
     test('Webview is ready action', () => {
@@ -11,22 +12,25 @@ describe('Page Map redux actions', () => {
     });
 
     test('Fetch `tutorials` action', () => {
-        const options: types.TutorialsSearchQuery = {
+        const query: types.TutorialsSearchQuery = {
             rows: 5,
             start: 2,
             searchField: ''
         };
+        const filters: TutorialsTagWithTitle[] = [];
         const expectedAction = {
             type: types.TUTORIALS_FETCH_TUTORIALS,
-            options: options,
+            query: query,
+            filters: filters,
             home: false
         };
-        const action = actions.tutorialsFetchTutorials(options, false);
+
+        const action = actions.tutorialsFetchTutorials(query, filters, false);
         expect(action).toEqual(expectedAction);
     });
 
     test('Fetch `blogs` action', () => {
-        const options: types.BlogsSearchQuery = {
+        const query: types.BlogsSearchQuery = {
             page: 0,
             limit: 20,
             orderBy: 'UPDATE_TIME',
@@ -47,13 +51,15 @@ describe('Page Map redux actions', () => {
             additionalManagedTags: [],
             additionalUserTags: []
         };
-
+        const filters: BlogFiltersEntry[] = [];
         const expectedAction = {
             type: types.BLOGS_FETCH_BLOGS,
-            options: options,
+            query: query,
+            filters: filters,
             home: false
         };
-        const action = actions.blogsFetchBlogs(options, false);
+
+        const action = actions.blogsFetchBlogs(query, filters, false);
         expect(action).toEqual(expectedAction);
     });
 });


### PR DESCRIPTION
# Provide saved filters for users

#34 

## Description

- [x] add a storage class to ide-extension to be able to store current filters
- [x] retrieve saved filters when starting extension 

## Checklist for Pull Requests

- [ ] Supplied as many details as possible on this change
- [ ] Included the link to the associated issue in the Issue section above
- [ ] The code conforms to the general [development guidelines](https://github.com/SAP/knowledge-hub-extension/blob/main/docs/developer-guide.md).
- [ ] The code has **unit tests** where applicable and is easily unit-testable
- [ ] This branch is appropriately named for the associated issue
