### PR TITLE
chore: update node version to 16 in workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -125,10 +125,10 @@ jobs:
                   key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pnpm-lock.yaml') }}
                   restore-keys: |
                       ${{ runner.os }}-build-${{ env.cache-name }}-
-            - name: Use Node.js 14.x
+            - name: Use Node.js 16.x
               uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 16.x
             - name: Install pnpm modules
               run: pnpm install
             - name: Run build


### PR DESCRIPTION
# Issue

The release step in the CI/CD workflow fails due to incorrect node version being used. See log [here](https://github.com/SAP/knowledge-hub-extension/actions/runs/4746143583/jobs/8429533895).

## Description

* Update node version to 16 in release step of CI/CD workflow

## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [ ] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/knowledge-hub-extension/blob/main/docs/developer-guide.md).
- [ ] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
