### PR TITLE
fix: remove version from pnpm/action-setup, use from packageManager

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,7 +22,6 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.4
               with:
-                  version: 8.6.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3
@@ -69,7 +68,6 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.4
               with:
-                  version: 8.6.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3
@@ -114,7 +112,6 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v2.2.4
               with:
-                  version: 8.6.0
                   run_install: true
             - name: Cache pnpm modules
               uses: actions/cache@v3


### PR DESCRIPTION
# Issue
Version of `pnpm` maintained in multiple places.

## Description
The GitHub action pnpm/action-setup@{version} does not need a version property, if a packageManager field in package.json is present, see also https://github.com/pnpm/action-setup#version.

This PR removes all version fields for pnpm/action-setup. This allows to control the version of pnpm solely in one place:
https://github.com/SAP/knowledge-hub-extension/blob/b90b4158f2ad06e0cb88d732d013c12e25143113/package.json#L52
## Checklist for Pull Requests

- [x] Supplied as many details as possible on this change
- [x] Included the link to the associated issue in the Issue section above
- [x] The code conforms to the general [development guidelines](https://github.com/SAP/knowledge-hub-extension/blob/main/docs/developer-guide.md).
- [x] The code has **unit tests** where applicable and is easily unit-testable
- [x] This branch is appropriately named for the associated issue
